### PR TITLE
Add stack.yaml environment variable interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ Set this buildpack on an exiting app:
 
     $ heroku buildpacks:set https://github.com/mfine/heroku-buildpack-stack
 
+Interpolating Environment Variables in `stack.yaml`:
+
+1. Create a `stack.vars` file at the project root
+1. Enter the environment variables you would like to replace, one per line
+1. In the `stack.yaml`, reference the variables by surrounding them with two curly braces like this: `{{<ENV_VAR>}}`
+
+
 [1]: https://github.com/mfine/heroku-buildpack-stack
 [2]: http://devcenter.heroku.com/articles/buildpacks
 [3]: https://github.com/commercialhaskell/stack

--- a/bin/compile
+++ b/bin/compile
@@ -15,6 +15,14 @@ function speak (){
 
 speak "Starting..."
 
+if [ -e "$1/stack.vars" ]; then
+  while read ln ; do
+    KEY=$ln
+    VALUE=${!KEY}
+    sed -ib "s/{{$KEY}}/$VALUE/g;" stack.yaml
+  done < stack.vars
+fi
+
 BLACKLIST_REGEX="^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH)$"
 if [ -d "$ENV_DIR" ]; then
   speak "Exporting config vars"

--- a/bin/compile
+++ b/bin/compile
@@ -15,13 +15,6 @@ function speak (){
 
 speak "Starting..."
 
-if [ -e "$1/stack.vars" ]; then
-  while read ln ; do
-    KEY=$ln
-    VALUE=${!KEY}
-    sed -ib "s/{{$KEY}}/$VALUE/g;" stack.yaml
-  done < stack.vars
-fi
 
 BLACKLIST_REGEX="^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH)$"
 if [ -d "$ENV_DIR" ]; then
@@ -31,6 +24,14 @@ if [ -d "$ENV_DIR" ]; then
     export "$e=$(cat $ENV_DIR/$e)"
     :
   done
+fi
+
+if [ -e "$BUILD_DIR/stack.vars" ]; then
+  while read ln ; do
+    KEY=$ln
+    VALUE=${!KEY}
+    sed -ib "s/{{$KEY}}/$VALUE/g;" "$BUILD_DIR/stack.yaml"
+  done < "$BUILD_DIR/stack.vars"
 fi
 
 WORK_DIR=/app

--- a/bin/detect
+++ b/bin/detect
@@ -1,12 +1,5 @@
 #!/usr/bin/env bash
 
-if [ -e "$1/stack.vars" ]; then
-  while read ln ; do
-    KEY=$ln
-    VALUE=${!KEY}
-    sed -ib "s/{{$KEY}}/$VALUE/g;" stack.yaml
-  done < stack.vars
-fi
 
 if [ -n "$(find "$1" -name stack.yaml -print -quit)" ]; then
   echo "Haskell"

--- a/bin/detect
+++ b/bin/detect
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+if [ -e "$1/stack.vars" ]; then
+  while read ln ; do
+    KEY=$ln
+    VALUE=${!KEY}
+    sed -ib "s/{{$KEY}}/$VALUE/g;" stack.yaml
+  done < stack.vars
+fi
+
 if [ -n "$(find "$1" -name stack.yaml -print -quit)" ]; then
   echo "Haskell"
   exit 0

--- a/bin/detect
+++ b/bin/detect
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-
 if [ -n "$(find "$1" -name stack.yaml -print -quit)" ]; then
   echo "Haskell"
   exit 0


### PR DESCRIPTION
Nice work getting this up and running w/ Stack!

This is a small hack to allow env-variable interpolation in the `stack.yaml`. Private repos that we depend on have been causing some problems in our build structure lately. This allows us to safely include passwords in the git `https` addresses w/o needing to commit those passwords to a repo.
