### PR TITLE
Template stack.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,29 @@ Set this buildpack on an exiting app:
 
     $ heroku buildpacks:set https://github.com/mfine/heroku-buildpack-stack
 
+### Templating stack.yaml
+
+To avoid committing secrets into `stack.yaml` for access to private
+repos, an app's config vars values can be substituted for tags
+enclosed in double brackets. For example, given a `stack.yaml` containing:
+
+    packages:
+    -location:
+        git: https://mfine:{{GITPASS}}@github.com/mfine/heroku-buildpack-stack.git
+
+and an application with config vars:
+
+    $ heroku config -app calm-storm-51595
+    === murmuring-beyond-51595 Config Vars
+    GITPASS: abc123
+    $
+
+before compilation, the `stack.yaml` will be substituted as follows:
+
+    packages:
+    -location:
+        git: https://mfine:abc123@github.com/mfine/heroku-buildpack-stack.git
+
 [1]: https://github.com/mfine/heroku-buildpack-stack
 [2]: http://devcenter.heroku.com/articles/buildpacks
 [3]: https://github.com/commercialhaskell/stack

--- a/bin/compile
+++ b/bin/compile
@@ -63,7 +63,7 @@ speak "Restoring $LIBGMP_VER files from cache"
 rsync -avq "$LIBGMP_DIR/ghc-libs/" "$WORK_DIR/vendor/ghc-libs"
 
 ########## stack exe ###############################################
-STACK_VER=${STACK_VER:-1.0.4}
+STACK_VER=${STACK_VER:-1.1.2}
 STACK_URL=${STACK_URL:-https://github.com/commercialhaskell/stack/releases/download/v"$STACK_VER"/stack-"$STACK_VER"-linux-x86_64.tar.gz}
 STACK_DIR="$CACHE_DIR/stack-$STACK_VER"
 STACK_EXE="$STACK_DIR/stack"
@@ -75,6 +75,14 @@ fi
 speak "Restoring stack-$STACK_VER"
 rsync -avq "$STACK_EXE" "$WORK_DIR/vendor/bin/stack"
 chmod a+x "$WORK_DIR/vendor/bin/stack"
+
+########## stack vars ##############################################
+if [ -d "$ENV_DIR" ]; then
+  speak "Substituting stack vars"
+  for e in $(ls "$ENV_DIR"); do
+    sed -i "s/{{$e}}/$(cat $ENV_DIR/$e)/g" "$BUILD_DIR/stack.yaml"
+  done
+fi
 
 ########## project build ###########################################
 speak "Running stack"

--- a/bin/detect
+++ b/bin/detect
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [ -n "$(find "$1" -name stack.yaml -print -quit)" ]; then
+if [ -n "$(find "$1" -name stack.yaml -maxdepth 1 -print -quit)" ]; then
   echo "Haskell"
   exit 0
 else


### PR DESCRIPTION
Allow the `stack.yaml` file to be templated by config vars before compilation. This will allow secrets and other sensitive information to be represented by tags and substituted with values from config vars before compile time.

/cc @ChrisCoffey 
