### PR TITLE
Bump stack version

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -63,7 +63,7 @@ speak "Restoring $LIBGMP_VER files from cache"
 cp -R "$LIBGMP_DIR/ghc-libs/." "$WORK_DIR/vendor/ghc-libs"
 
 ########## stack exe ###############################################
-STACK_VER=${STACK_VER:-1.1.2}
+STACK_VER=${STACK_VER:-1.2.0}
 STACK_URL=${STACK_URL:-https://github.com/commercialhaskell/stack/releases/download/v"$STACK_VER"/stack-"$STACK_VER"-linux-x86_64.tar.gz}
 STACK_DIR="$CACHE_DIR/stack-$STACK_VER"
 STACK_EXE="$STACK_DIR/stack"


### PR DESCRIPTION
Hi there,

Just updating the buildpack to use the [latest version of stack](https://github.com/commercialhaskell/stack/releases/tag/v1.2.0).

Thanks for the buildpack!
