### PR TITLE
Adding Makefile functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ before compilation, the `stack.yaml` will be substituted as follows:
     -location:
         git: https://mfine:abc123@github.com/mfine/heroku-buildpack-stack.git
 
+
+### Makefile Support
+This buildpack now supports an optional Makefile, in case you need to coordinate other build steps with Stack. It assumes that the Makefile includes a `make install` target that uses the Stack build command with the flag `--copy-bins`. For example, a possible `install` target configuration in the Makefile could be:
+
+    install: stack build --copy-bins
+
 [1]: https://github.com/mfine/heroku-buildpack-stack
 [2]: http://devcenter.heroku.com/articles/buildpacks
 [3]: https://github.com/commercialhaskell/stack

--- a/bin/compile
+++ b/bin/compile
@@ -97,9 +97,11 @@ cd "$WORK_DIR"
 if [ -f "$BUILD_DIR/Makefile" ]; then
     speak "Makefile detected"
     make -C "$BUILD_DIR"
+    make -C "$BUILD_DIR" install
+else
+    stack setup
+    stack build --fast --copy-bins
 fi
-stack setup
-stack build --fast --copy-bins
 
 # Set context environment variables.
 set-env PATH "$WORK_DIR/.local/bin:$PATH"

--- a/bin/compile
+++ b/bin/compile
@@ -93,6 +93,11 @@ fi
 
 speak "Running stack"
 cd "$WORK_DIR"
+# Makefile support (if you need other build tools than Stack that you need to use in conjunction)
+if [ -f "$BUILD_DIR/Makefile" ]; then
+    speak "Makefile detected"
+    make -C "$BUILD_DIR"
+fi
 stack setup
 stack build --fast --copy-bins
 
@@ -109,6 +114,6 @@ mv "$WORK_DIR/.local/bin" "$BUILD_DIR/.local"
 
 speak "Caching .stack-work"
 rsync -avq "$WORK_DIR/.stack-work/" "$SANDBOX_DIR"
-mv "$WORK_DIR/.stack-work" "$BUILD_DIR"
+cp -Rp "$WORK_DIR/.stack-work" "$BUILD_DIR"
 
 speak "Finished!"


### PR DESCRIPTION
In order to deploy projects that wrap a Makefile around Stack commands, I would like the option of executing the default Makefile action rather than the default Stack setup and build commands if a Makefile is provided.

We need functionality like this in order to deploy apps like https://github.com/haskell-servant/example-servant-elm