### PR TITLE
add a `Procfile.example`, plus corresponding explanation in `README.md`

### DIFF
--- a/Procfile.example
+++ b/Procfile.example
@@ -1,1 +1,1 @@
-web: /app/.local/bin/YOURAPPNAME-exe
+web: YOURAPPNAME-exe   # $ cat *.cabal | grep executable

--- a/Procfile.example
+++ b/Procfile.example
@@ -1,0 +1,1 @@
+web: /app/.local/bin/YOURAPPNAME-exe

--- a/README.md
+++ b/README.md
@@ -12,9 +12,13 @@ Set this buildpack on an existing app:
 
     $ heroku buildpacks:set https://github.com/mfine/heroku-buildpack-stack
 
-Then, assuming your application is [binding to `$PORT`](https://devcenter.heroku.com/articles/dynos#web-dynos), run your app by [creating a `Procfile`](https://devcenter.heroku.com/articles/procfile) at your project root:
+Binary executables are placed in `/app/.local/bin/` after compilation, a directory which Heroku includes in your `$PATH`, so assuming that your application is [binding to `$PORT`](https://devcenter.heroku.com/articles/dynos#web-dynos), you can serve your app by [creating a `Procfile`](https://devcenter.heroku.com/articles/procfile) at your project root that defines a `web` process type for the `executable` defined in your `.cabal` file:
 
-    $ echo "web: /app/.local/bin/YOURAPPNAME-exe" >> Procfile
+    $ cat *.cabal | grep executable
+    executable YOURAPPNAME-exe
+
+    $ echo "web: YOURAPPNAME-exe" >> Procfile
+
 
 ### Templating stack.yaml
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Set this buildpack on an existing app:
 
     $ heroku buildpacks:set https://github.com/mfine/heroku-buildpack-stack
 
+Then, assuming your application is [binding to `$PORT`](https://devcenter.heroku.com/articles/dynos#web-dynos), run your app by [creating a `Procfile`](https://devcenter.heroku.com/articles/procfile) at your project root:
+
+    $ echo "web: /app/.local/bin/YOURAPPNAME-exe" >> Procfile
+
 ### Templating stack.yaml
 
 To avoid committing secrets into `stack.yaml` for access to private


### PR DESCRIPTION
First off, thanks so much for this buildpack! I'm just getting started with Haskell, and was thrilled to find I could use Stack + Heroku this easily. Seriously, thank you!

After my first deploy, I missed the helpful message about `app/.local/bin`, and ended up pointing my `Procfile` to the binary in `.stack-work`, before noticing it contained version numbers, and deciding that was an absolutely terrible idea. I eventually found the message, but figured adding a `Procfile.example` and some notes to `Usage` might save the next newbie a few minutes time!