### PR TITLE
Use the $PATH at runtime for .profile.d scripts

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -104,7 +104,7 @@ else
 fi
 
 # Set context environment variables.
-set-env PATH "$WORK_DIR/.local/bin:$PATH"
+set-env PATH "$WORK_DIR/.local/bin:\$PATH"
 set-default-env LIBRARY_PATH "$WORK_DIR/vendor/ghc-libs:/usr/lib"
 set-default-env LD_LIBRARY_PATH "$WORK_DIR/vendor/ghc-libs:/usr/lib"
 


### PR DESCRIPTION
Setting `PATH` to `$PATH` for `.profile.d` scripts will include the build time `PATH` and not the one at runtime. This means this buildpack will override any PATH'ng set by any other buildpacks if the `.profile.d` script is run after.