### PR TITLE
Remove --fast

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -100,7 +100,7 @@ if [ -f "$BUILD_DIR/Makefile" ]; then
     make install
 else
     stack setup
-    stack build --fast --copy-bins
+    stack build --copy-bins
 fi
 
 # Set context environment variables.


### PR DESCRIPTION
Remove the `--fast` flag by default - the Makefile can be used to specify alternative stack building behavior. Don't penalize everyone with `--fast` by default.

Fixes #30 